### PR TITLE
Add "state of the repository" table to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,20 @@ Of these,
 
 The following table specify if each binary has been matched or not, and if it has their functions matching or the whole binary/elf.
 
-| Program | 5.3 functions | 5.3 elf | 7.1 functions | 7.1 elf |
-| -       | -   | -   | -   | -   |
-| `cc`    | :x: | :x: | :heavy_check_mark: | :x: |
-| `cfe`   | :x: | :x: | :x: | :x: |
-| `uopt`  | :x: | :x: | :x: | :x: |
-| `ugen`  | :x: | :x: | :x: | :x: |
-| `as1`   | :x: | :x: | :x: | :x: |
-| `as0`   | :x: | :x: | :x: | :x: |
-| `ld`    | :x: | :x: | :x: | :x: |
-| `uld`   | :x: | :x: | :x: | :x: |
-| `upas`  | :x: | :x: | :x: | :x: |
+| Program   | 5.3 functions | 5.3 elf | 7.1 functions | 7.1 elf |
+| -         | -   | -   | -   | -   |
+| `cc`      | :x: | :x: | :heavy_check_mark: | :x: |
+| `cfe`     | :x: | :x: | :x: | :x: |
+| `uopt`    | :x: | :x: | :x: | :x: |
+| `ugen`    | :x: | :x: | :x: | :x: |
+| `as1`     | :x: | :x: | :x: | :x: |
+| `as0`     | :x: | :x: | :x: | :x: |
+| `ld`      | :x: | :x: | :x: | :x: |
+| `uld`     | :x: | :x: | :x: | :x: |
+| `umerge`  | :x: | :x: | :x: | :x: |
+| `upas`    | :x: | :x: | :x: | :x: |
+| `ujoin`   | :x: | :x: | :x: | :x: |
+| `usplit`  | :x: | :x: | :x: | :x: |
 
 ## Build dependencies
 


### PR DESCRIPTION
Add a table specifying which binaries has been matched and which haven't to the readme.

Since matching the elfs has been so problematic, I decided to make the elf matching a separated column.