### PR TITLE
Import cmplrs/*.h changes for IDO 7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ WERROR ?= 0
 CC_CHECK_COMP ?= gcc
 
 ifeq ($(VERSION),7.1)
-	IDO_VERSION := IDO71
+	IDO_VERSION := IDO_71
 #	IDO_TC      := cc acpp as0 as1 cfe copt ugen ujoin uld umerge uopt upas usplit
 	IDO_TC      := cc cfe ugen as1 umerge
 else ifeq ($(VERSION),5.3)
-	IDO_VERSION := IDO53
+	IDO_VERSION := IDO_53
 #	IDO_TC      := cc acpp as0 as1 cfe copt ld ugen ujoin uld umerge uopt usplit
 	IDO_TC      := cc cfe as0
 else

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,11 @@ WERROR ?= 0
 CC_CHECK_COMP ?= gcc
 
 ifeq ($(VERSION),7.1)
+	IDO_VERSION := IDO71
 #	IDO_TC      := cc acpp as0 as1 cfe copt ugen ujoin uld umerge uopt upas usplit
 	IDO_TC      := cc cfe ugen as1 umerge
 else ifeq ($(VERSION),5.3)
+	IDO_VERSION := IDO53
 #	IDO_TC      := cc acpp as0 as1 cfe copt ld ugen ujoin uld umerge uopt usplit
 	IDO_TC      := cc cfe as0
 else
@@ -94,7 +96,7 @@ MIPS_VERSION := -mips2
 ASFLAGS := -march=vr4300 -32 -Iinclude -KPIC
 
 IDO_WARNINGS := -fullwarn -woff 624,649,838,712,835
-CFLAGS += -G 0 -KPIC -Xcpluscomm $(IINC) -nostdinc -Wab,-r4300_mul $(IDO_WARNINGS)
+CFLAGS += -G 0 -KPIC -Xcpluscomm $(IINC) -nostdinc -Wab,-r4300_mul $(IDO_WARNINGS) -D$(IDO_VERSION)
 
 
 # -- Location of original IDO binaries

--- a/include/indy/cmplrs/binasm.h
+++ b/include/indy/cmplrs/binasm.h
@@ -255,7 +255,8 @@ type
   opt_type = (
 	o_undefined,
 	o_optimize,
-	o_pic
+	o_pic,
+	o_exception_info
 	);
 
   opt_arg_type = (
@@ -270,6 +271,7 @@ type
   reg_compat_align = firstof(registers)..lastof(registers) of integer;
   form_compat_align = firstof(format)..lastof(format) of integer;
   form_extn_compat_align = firstof(format_extn)..lastof(format_extn) of integer;
+  opt_compat_align = firstof(opt_type)..lastof(opt_type) of integer;
 
   binasm = packed record
     case kind of
@@ -363,7 +365,11 @@ type
 		frrl : ();		{ reg1, reg2, sym		      }
 	      );
 	    ioption: (
+#if IDO53
 	      option: opt_type;		{ which option (e.g. "O" for "-O3")   }
+#elif IDO71
+	      option: opt_compat_align;	{ which 2-bit option (e.g. "O" for "-O3")  }
+#endif
 	      fill04: 0 .. 16#3fffffff; { pad to 32-bit boundary	      }
 	      case opt_arg_type of	{ associated arg (e.g. "3" for "-O3") }
 		opt_none: ();
@@ -621,10 +627,11 @@ typedef enum {
 typedef enum {
 	o_undefined,
 	o_optimize,
-	o_pic
+	o_pic,
+	o_exception_info
     } opt_type;
 
-#define n_opt_type	 3
+#define n_opt_type	 4
 
 
 typedef enum {

--- a/include/indy/cmplrs/binasm.h
+++ b/include/indy/cmplrs/binasm.h
@@ -365,10 +365,10 @@ type
 		frrl : ();		{ reg1, reg2, sym		      }
 	      );
 	    ioption: (
-#if IDO53
-	      option: opt_type;		{ which option (e.g. "O" for "-O3")   }
-#elif IDO71
+#ifdef IDO_71
 	      option: opt_compat_align;	{ which 2-bit option (e.g. "O" for "-O3")  }
+#else
+	      option: opt_type;		{ which option (e.g. "O" for "-O3")   }
 #endif
 	      fill04: 0 .. 16#3fffffff; { pad to 32-bit boundary	      }
 	      case opt_arg_type of	{ associated arg (e.g. "3" for "-O3") }

--- a/include/indy/cmplrs/uoptions.h
+++ b/include/indy/cmplrs/uoptions.h
@@ -33,6 +33,8 @@
 				   compilation will involving generating
 				   the ascii assembler file and calling as0
 				   to translate it back to binary assembler */
+#define UCO_EXC_INFO    8	/* this option specifies the the option value is the
+				   block number of an exception_info variable */
 
 /* Option names for the OPTN UCO_SOURCE that specifies the source language */
 #define PASCAL_SOURCE		1


### PR DESCRIPTION
The `opt_compat_align` difference affects matching, for example in https://decomp.me/scratch/xul7d, so I hid it behind a version define. Not sure how to write the version so I copied it from ido-static-recomp